### PR TITLE
Usunięcie transferu podatku z kasyna do sejfu 19

### DIFF
--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -1707,7 +1707,6 @@ Kostka_Wygrana(playerid, loser, kasa, bool:quit=false)
         SetPVarInt(playerid, "kostka-player", 0);
     }
     Log(payLog, INFO, "%s wygra³ rzuty kostk¹ z %s na kwotê %d$ %s", GetPlayerLogName(playerid), GetPlayerLogName(loser), kasa, quit ? "(quit)" : "");
-    Sejf_Add(19, podatek);
 
 
     return 1;


### PR DESCRIPTION
Hajs w tym sejfie gromadził się w szybkim tempie - o ile pamiętam to średnio co 2 tygodnie przekręcała się zmienna. Moim zdaniem do usunięcia, zbyt duże ryzyko nadużyć (pozdro West <3) + niepotrzebnie zaśmieca logi.