### PR TITLE
Dodanie dystrybutora darmowego paliwa na dolnym parkingu LSPD (z możliwością na rozszerzenie dla innych frakcji).

### DIFF
--- a/gamemodes/commands/cmd/zatankuj.pwn
+++ b/gamemodes/commands/cmd/zatankuj.pwn
@@ -28,25 +28,31 @@
 	
 */
 
+static zatankujPojazdGracza(playerid)
+{
+	new engine, niewazne;
+	GetVehicleParamsEx(GetPlayerVehicleID(playerid), engine, niewazne, niewazne, niewazne, niewazne, niewazne, niewazne); 
+	if(engine == 1 || OdpalanieSpam[playerid] == 1) return SendClientMessage(playerid, COLOR_GREY, "Nie mo¿esz tankowaæ, gdy silnik jest odpalony!");
+	GameTextForPlayer(playerid,"~w~~n~~n~~n~~n~~n~~n~~n~~n~~n~Tankowanie pojazdu, prosze czekac",2000,3);
+	SetTimer("Fillup",RefuelWait,0);
+	Refueling[playerid] = 1;
+}
+
 YCMD:zatankuj(playerid, params[], help)
 {
     if(IsPlayerConnected(playerid))
     {
+		// zwyk³e stacje benzynowe
 		if(IsAtGasStation(playerid))
 		{
 		    if(IsPlayerInAnyVehicle(playerid))
 		    {
-                new engine, niewazne;
-                GetVehicleParamsEx(GetPlayerVehicleID(playerid), engine, niewazne, niewazne, niewazne, niewazne, niewazne, niewazne); 
-                if(engine == 1 || OdpalanieSpam[playerid] == 1) return SendClientMessage(playerid, COLOR_GREY, "Nie mo¿esz tankowaæ, gdy silnik jest odpalony!");
-                GameTextForPlayer(playerid,"~w~~n~~n~~n~~n~~n~~n~~n~~n~~n~Tankowanie pojazdu, prosze czekac",2000,3);
-				SetTimer("Fillup",RefuelWait,0);
-				Refueling[playerid] = 1;
+                zatankujPojazdGracza(playerid);
 			}
 		}
-		else
+		else if(IsAFractionGasStationValidUser(playerid) && IsPlayerInTheirFractionVehicle(playerid))
 		{
-			sendTipMessageEx(playerid,COLOR_GREY,"Nie jesteœ na stacji benzynowej!");
+			zatankujPojazdGracza(playerid);
 		}
 	}
 	return 1;

--- a/gamemodes/commands/cmd/zatankuj.pwn
+++ b/gamemodes/commands/cmd/zatankuj.pwn
@@ -42,17 +42,20 @@ YCMD:zatankuj(playerid, params[], help)
 {
     if(IsPlayerConnected(playerid))
     {
-		// zwyk³e stacje benzynowe
 		if(IsAtGasStation(playerid))
-		{
+		{ // zwyk³e stacje benzynowe
 		    if(IsPlayerInAnyVehicle(playerid))
 		    {
                 zatankujPojazdGracza(playerid);
 			}
 		}
 		else if(IsAFractionGasStationValidUser(playerid) && IsPlayerInTheirFractionVehicle(playerid))
-		{
+		{ // stacje benzynowe frakcyjne
 			zatankujPojazdGracza(playerid);
+		}
+		else
+		{
+			sendTipMessageEx(playerid,COLOR_GREY,"Nie jesteœ na stacji benzynowej!");
 		}
 	}
 	return 1;

--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -3677,6 +3677,33 @@ IsAtGasStation(playerid)
 	return 0;
 }
 
+IsPlayerInTheirFractionVehicle(playerid)
+{
+	new vehicleid = GetPlayerVehicleID(playerid);
+	if(vehicleid != 0)
+	{
+		new lcarid = VehicleUID[vehicleid][vUID];
+		if(CarData[lcarid][c_OwnerType] == CAR_OWNER_FRACTION && CarData[lcarid][c_Owner] == GetPlayerFraction(playerid))
+		{
+			return 1;
+		}
+	} 
+
+	return 0;
+}
+
+IsAFractionGasStationValidUser(playerid)
+{
+	if(IsPlayerConnected(playerid) && IsPlayerInTheirFractionVehicle(playerid))
+	{
+		if(GetPlayerFraction(playerid) == FRAC_LSPD && PlayerToPoint(12.0, playerid, 1530.2, -1673.4, 6.5))
+		{// tankowanie dla LSPD - parking dolny LSPD
+			return 1;
+		}
+	}
+	return 0;
+}
+
 IsAtBar(playerid)
 {
     if(IsPlayerConnected(playerid))

--- a/gamemodes/system/timery.pwn
+++ b/gamemodes/system/timery.pwn
@@ -3252,21 +3252,27 @@ public Fillup()
 		else FillUp = 0;
 		if(Refueling[i] == 1)
 		{
-			if(kaska[i] >= FillUp+4)
+			new FillUpPrice = FillUp * 120;
+
+			if(IsAFractionGasStationValidUser(i))
+			{// na frakcyjnych stacjach tankowanie za darmo dla cz?onków frakcji
+				FillUpPrice = 0;
+			}
+
+			if(kaska[i] >= FillUpPrice)
 			{
 				Gas[VID] += FillUp;
-				FillUp = FillUp * 120;
-				format(string,sizeof(string),"Pojazd zatankowany za: $%d.",FillUp);
+				format(string,sizeof(string),"Pojazd zatankowany za: $%d.",FillUpPrice);
 				SendClientMessage(i, COLOR_LIGHTBLUE,string);
-				ZabierzKase(i, FillUp);
-				Refueling[i] = 0;
+				ZabierzKase(i, FillUpPrice);
 			}
 			else
 			{
-				format(string,sizeof(string),"Nie posiadasz doœæ pieniêdzy ($%d) aby zatankowaæ ten pojazd.",FillUp);
+				format(string,sizeof(string),"Nie posiadasz doœæ pieniêdzy ($%d) aby zatankowaæ ten pojazd.", FillUpPrice);
 				sendErrorMessage(i,string);
-                Refueling[i] = 0;
 			}
+
+			Refueling[i] = 0;
 		}
 	}
 	return 1;

--- a/gamemodes/system/timery.pwn
+++ b/gamemodes/system/timery.pwn
@@ -3254,11 +3254,6 @@ public Fillup()
 		{
 			new FillUpPrice = FillUp * 120;
 
-			if(IsAFractionGasStationValidUser(i))
-			{// na frakcyjnych stacjach tankowanie za darmo dla cz?onków frakcji
-				FillUpPrice = 0;
-			}
-
 			if(kaska[i] >= FillUpPrice)
 			{
 				Gas[VID] += FillUp;


### PR DESCRIPTION
**Dodanie dystrybutora paliwa na dolnym parkingu LSPD.** 

Tankowanie z dystrybutora jest możliwe wyłącznie dla pojazdów frakcyjnych LSPD i nic nie kosztuje.

Możliwość rozszerzenia funkcjonalności na inne frakcje - każda frakcja może potencjalnie dodać swoje dystrybutory.

Przy okazji dodano pomocnicze funkcje (potrzebne do realizacji zmian):
- IsPlayerInTheirFractionVehicle - sprawdza czy gracz znajduje się w pojeździe swojej frakcji;
- IsAFractionGasStationValidUser - do sprawdzenia czy gracz może korzystać z frakcyjnej stacji paliw.

Naprawiono też bug związany z tankowaniem na stacji paliw - sprawdzanie czy gracz posiada wystarczającą kwotę było przeprowadzane nieodpowiednio. Gracz mógł zatankować, nawet gdy nie było go na to stać.