### PR TITLE
Dodanie zniżek dla pracowników organizacji porządkowych - LSPD, FBI, …

### DIFF
--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -2453,6 +2453,11 @@ IsABOR(playerid)
 	return 0;
 }
 
+IsAPorzadkowy(playerid)
+{
+	return IsAPolicja(playerid) || IsAMedyk(playerid) || IsABOR(playerid);
+}
+
 /*
 MozePobic(playerid)
 {
@@ -3674,6 +3679,21 @@ IsAtGasStation(playerid)
 			return 1;
 		}
 	}
+	return 0;
+}
+
+IsPlayerInTheirFractionVehicle(playerid)
+{
+	new vehicleid = GetPlayerVehicleID(playerid);
+	if(vehicleid != 0)
+	{
+		new lcarid = VehicleUID[vehicleid][vUID];
+		if(CarData[lcarid][c_OwnerType] == CAR_OWNER_FRACTION && CarData[lcarid][c_Owner] == GetPlayerFraction(playerid))
+		{
+			return 1;
+		}
+	} 
+
 	return 0;
 }
 

--- a/gamemodes/system/timery.pwn
+++ b/gamemodes/system/timery.pwn
@@ -2371,8 +2371,16 @@ public JednaSekundaTimer()
 					GetVehicleHealth(vehicleid, health);
 					if(health <= 999)
 					{
-				        sendTipMessageFormat(i, "Zap³aci³eœ $%d za wizytê w warsztacie", 7500);
-				        ZabierzKase(i, 7500);
+						new cena_naprawy = 7500;
+
+						if(IsAPorzadkowy(i) && IsPlayerInTheirFractionVehicle(i))
+						{// 25% (GovernmentServicesPriceMultiplier) ceny za naprawê w sprayu dla frakcji porz¹dkowych
+							new Float:GovernmentServicesPriceMultiplier = 0.25;
+							cena_naprawy = floatround(float(cena_naprawy) * GovernmentServicesPriceMultiplier);
+						}
+
+				        sendTipMessageFormat(i, "Zap³aci³eœ $%d za wizytê w warsztacie", cena_naprawy);
+				        ZabierzKase(i, cena_naprawy);
 						RepairVehicle(vehicleid);
 						naprawiony[i] = 1;
 						SetTimerEx("Naprawianie",10000,0,"d",i);
@@ -3252,21 +3260,28 @@ public Fillup()
 		else FillUp = 0;
 		if(Refueling[i] == 1)
 		{
-			if(kaska[i] >= FillUp+4)
+			new FillUpPrice = FillUp * 120;
+
+			if(IsAPorzadkowy(i) && IsPlayerInTheirFractionVehicle(i))
+			{// na zwyk³ych stacjach 25% (GovernmentServicesPriceMultiplier) ceny za paliwo dla frakcji porz¹dkowych
+				new Float:GovernmentServicesPriceMultiplier = 0.25;
+				FillUpPrice = floatround(GovernmentServicesPriceMultiplier * float(FillUpPrice));
+			}
+
+			if(kaska[i] >= FillUpPrice)
 			{
 				Gas[VID] += FillUp;
-				FillUp = FillUp * 120;
-				format(string,sizeof(string),"Pojazd zatankowany za: $%d.",FillUp);
+				format(string,sizeof(string),"Pojazd zatankowany za: $%d.",FillUpPrice);
 				SendClientMessage(i, COLOR_LIGHTBLUE,string);
-				ZabierzKase(i, FillUp);
-				Refueling[i] = 0;
+				ZabierzKase(i, FillUpPrice);
 			}
 			else
 			{
-				format(string,sizeof(string),"Nie posiadasz doœæ pieniêdzy ($%d) aby zatankowaæ ten pojazd.",FillUp);
+				format(string,sizeof(string),"Nie posiadasz doœæ pieniêdzy ($%d) aby zatankowaæ ten pojazd.", FillUpPrice);
 				sendErrorMessage(i,string);
-                Refueling[i] = 0;
 			}
+
+			Refueling[i] = 0;
 		}
 	}
 	return 1;

--- a/gamemodes/system/timery.pwn
+++ b/gamemodes/system/timery.pwn
@@ -2374,9 +2374,15 @@ public JednaSekundaTimer()
 						new cena_naprawy = 7500;
 
 						if(IsAPorzadkowy(i) && IsPlayerInTheirFractionVehicle(i))
-						{// 25% (GovernmentServicesPriceMultiplier) ceny za naprawê w sprayu dla frakcji porz¹dkowych
-							new Float:GovernmentServicesPriceMultiplier = 0.25;
-							cena_naprawy = floatround(float(cena_naprawy) * GovernmentServicesPriceMultiplier);
+						{// dla pojazdów frakcji porz¹dkowych 50% nale¿noœci idzie z sejfu
+							new player_frac = GetPlayerFraction(i);
+							new price_half = floatround(0.5 * float(cena_naprawy));
+							if(Sejf_Frakcji[player_frac] >= price_half)
+							{
+								Sejf_Add(player_frac, -price_half);
+								cena_naprawy = price_half;
+								SendClientMessage(i, COLOR_LIGHTBLUE,"Po³owa kosztów naprawy zosta³a op³acona ze œrodków frakcji.");
+							}
 						}
 
 				        sendTipMessageFormat(i, "Zap³aci³eœ $%d za wizytê w warsztacie", cena_naprawy);
@@ -3263,9 +3269,15 @@ public Fillup()
 			new FillUpPrice = FillUp * 120;
 
 			if(IsAPorzadkowy(i) && IsPlayerInTheirFractionVehicle(i))
-			{// na zwyk³ych stacjach 25% (GovernmentServicesPriceMultiplier) ceny za paliwo dla frakcji porz¹dkowych
-				new Float:GovernmentServicesPriceMultiplier = 0.25;
-				FillUpPrice = floatround(GovernmentServicesPriceMultiplier * float(FillUpPrice));
+			{// dla pojazdów frakcji porz¹dkowych 50% nale¿noœci idzie z sejfu
+				new player_frac = GetPlayerFraction(i);
+				new price_half = floatround(0.5 * float(FillUpPrice));
+				if(Sejf_Frakcji[player_frac] >= price_half)
+				{
+					Sejf_Add(player_frac, -price_half);
+					FillUpPrice = price_half;
+					SendClientMessage(i, COLOR_LIGHTBLUE,"Po³owa kosztów tankowania zosta³a op³acona ze œrodków frakcji.");
+				}
 			}
 
 			if(kaska[i] >= FillUpPrice)


### PR DESCRIPTION
…NG, SAM-ERS, BOR.

Pracownicy tych organizacji płacą 25% ceny tankowania na stacjach paliw w całym San Andreas oraz 25% ceny naprawy w warsztatach na terenie całego stanu. Uwaga - zniżka dotyczy **wyłącznie pojazdów służbowych**.

Przy okazji dodano pomocnicze funkcje (potrzebne do realizacji zmian):
- IsPlayerInTheirFractionVehicle - sprawdza czy gracz znajduje się w pojeździe swojej frakcji;
- IsAPorzadkowy - sprawdza czy gracz należy do LSPD, FBI, NG, SAM-ERS, BOR.

Naprawiono też bug związany z tankowaniem na stacji paliw - sprawdzanie czy gracz posiada wystarczającą kwotę było przeprowadzane nieodpowiednio. Gracz mógł zatankować, nawet gdy nie było go na to stać.