### PR TITLE
Antyczit: złośliwe respawnowanie pojazdów oraz lagowanie kłębowiskami pojazdów

### DIFF
--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -84,7 +84,7 @@ Mrucznik® Role Play ----> stworzy³ Mrucznik
 #include <indirection>
 #include <amx_assembly\addressof>
 //redefinition from y_playerarray.inc
-#undef PlayerArray 
+#undef PlayerArray
 
 #include <colandreas>
 #include <colandreas_streamer_integrate>
@@ -6542,8 +6542,6 @@ public OnPlayerKeyStateChange(playerid,newkeys,oldkeys)
 
 public OnVehicleDeath(vehicleid, killerid)
 {
-	AC_AntyVehFakeRespawn(vehicleid, killerid);
-
 	if(GetVehicleModel(vehicleid) == 577)
 	{
         foreach(new i : Player)

--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -6528,6 +6528,8 @@ public OnPlayerKeyStateChange(playerid,newkeys,oldkeys)
 
 public OnVehicleDeath(vehicleid, killerid)
 {
+	AC_AntyVehFakeRespawn(vehicleid, killerid);
+
 	if(GetVehicleModel(vehicleid) == 577)
 	{
         foreach(new i : Player)

--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -2118,7 +2118,7 @@ public OnPlayerSpawn(playerid)
 	{
 		if(GetPVarInt(playerid, "Lockdown-izolacja") != 0)
 		{
-			SetPlayerVirtualWorld(playerid, Lockdown_assignedVW[playerid]);
+			ALockdown_SetLockdownVW(playerid);
 		}
 		else
 			SetPlayerVirtualWorld(playerid, 0);
@@ -2361,7 +2361,7 @@ SetPlayerSpawnPos(playerid)
 			Wchodzenie(playerid);
 			SetPlayerPos(playerid, PlayerInfo[playerid][pPos_x], PlayerInfo[playerid][pPos_y], PlayerInfo[playerid][pPos_z]);
 			SetPlayerInterior(playerid, PlayerInfo[playerid][pInt]);
-			if(GetPVarInt(playerid, "Lockdown-izolacja") != 0) SetPlayerVirtualWorld(playerid, Lockdown_assignedVW[playerid]);
+			if(GetPVarInt(playerid, "Lockdown-izolacja") != 0) ALockdown_SetLockdownVW(playerid);
 			else SetPlayerVirtualWorld(playerid, PlayerInfo[playerid][pVW]);
 			if(GetPLocal(playerid) == PLOCAL_INNE_BANK || GetPLocal(playerid) == PLOCAL_FRAC_DMV)
 	        {
@@ -2378,7 +2378,7 @@ SetPlayerSpawnPos(playerid)
 		    {
 		        SetPlayerInteriorEx(playerid, 0);
 		        PlayerInfo[playerid][pLocal] = 255;
-				if(GetPVarInt(playerid, "Lockdown-izolacja") != 0) SetPlayerVirtualWorld(playerid, Lockdown_assignedVW[playerid]);
+				if(GetPVarInt(playerid, "Lockdown-izolacja") != 0) ALockdown_SetLockdownVW(playerid);
 				else SetPlayerVirtualWorld(playerid, 0); 
 				if(GetPlayerFraction(playerid) > 0) //Spawn Frakcji
 				{

--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -65,7 +65,6 @@ Mrucznik® Role Play ----> stworzy³ Mrucznik
 // actors https://github.com/Dayrion/actor_plus
 // #include <PawnPlus>
 // #include <requests>
-// #include <colandreas>
 
 //-------<[ Include ]>-------
 #include <a_http>
@@ -86,6 +85,10 @@ Mrucznik® Role Play ----> stworzy³ Mrucznik
 #include <amx_assembly\addressof>
 //redefinition from y_playerarray.inc
 #undef PlayerArray 
+
+#include <colandreas>
+#include <colandreas_streamer_integrate>
+
 #include <sort-inline>
 //nex-ac settings
 #define AC_MAX_CONNECTS_FROM_IP		3
@@ -95,9 +98,10 @@ Mrucznik® Role Play ----> stworzy³ Mrucznik
 #define AC_USE_AMMUNATIONS false
 #define AC_USE_RESTAURANTS false
 #define AC_USE_CASINOS false
+#include <progress2>
+#include <Pawn.RakNet>
 #include <nex-ac>
 #include <md5>
-#include <progress2>
 #include <double-o-files2>
 #include <dialogs>
 #include <fadescreen>
@@ -108,6 +112,16 @@ Mrucznik® Role Play ----> stworzy³ Mrucznik
 #include <vector>
 #include <map>
 #include <mapfix>
+
+#if defined _colandreas_included
+	#include "obiekty\colandreas_removebuildings.pwn"
+	hook OnGameModeInit()
+	{
+		printf("ColAndreas - usuwanie budynków i inicjalizacja mapy.");
+		ColAndreas_UsunBudynki();
+		CA_Init();
+	}
+#endif
 
 //--------------------------------------<[ G³ówne ustawienia ]>----------------------------------------------//
 //-                                                                                                         -//
@@ -266,7 +280,7 @@ public OnGameModeInit()
 	//-------<[ MySQL ]>-------
 	MruMySQL_Connect();//mysql
 	MruMySQL_IloscLiderowLoad();
-
+	
 	
 	DefaultItems_LicenseCost();
 

--- a/gamemodes/commands/cmd/kup.pwn
+++ b/gamemodes/commands/cmd/kup.pwn
@@ -30,7 +30,7 @@
 
 ShowShopDialog(playerid)
 {
-	ShowPlayerDialogEx(playerid,12,DIALOG_STYLE_LIST,"Sklep 24/7","Zdrapka\t\t\t50000$\nTelefon\t\t\t\t500$\nKsiπøka telefoniczna\t\t5000$\nKostka\t\t\t\t500$\nAparat Fotograficzny\t\t5000$\nZamek\t\t\t\t10000$\nPrÍdkoúciomierz\t\t5000$\nKondom\t\t\t50$\nOdtwarzacz MP3\t\t2500$\nPiwo Mruczny Gul\t\t20$\nWino Komandaos\t\t25$\nSprunk\t\t\t\t15$\nCB-Radio\t\t\t2500$\nCygara\t\t\t\t200$\nKij Baseballowy\t\t\t15000$\nTempomat\t\t\t35000$\nMroøony kurczak\t\t15$\nMroøona pizza\t\t\t30$\nMroøony hamburger\t\t25$\nMaseczka ochronna\t\t15000$","KUP","WYJDè");	
+	ShowPlayerDialogEx(playerid,12,DIALOG_STYLE_LIST,"Sklep 24/7","Zdrapka\t\t\t56500$\nTelefon\t\t\t\t500$\nKsiπøka telefoniczna\t\t5000$\nKostka\t\t\t\t500$\nAparat Fotograficzny\t\t5000$\nZamek\t\t\t\t10000$\nPrÍdkoúciomierz\t\t5000$\nKondom\t\t\t50$\nOdtwarzacz MP3\t\t2500$\nPiwo Mruczny Gul\t\t20$\nWino Komandaos\t\t25$\nSprunk\t\t\t\t15$\nCB-Radio\t\t\t2500$\nCygara\t\t\t\t200$\nKij Baseballowy\t\t\t15000$\nTempomat\t\t\t35000$\nMroøony kurczak\t\t15$\nMroøona pizza\t\t\t30$\nMroøony hamburger\t\t25$\nMaseczka ochronna\t\t15000$","KUP","WYJDè");	
 }
 
 YCMD:kup(playerid, params[], help)

--- a/gamemodes/commands/cmd/zaparkuj.pwn
+++ b/gamemodes/commands/cmd/zaparkuj.pwn
@@ -31,43 +31,33 @@
 YCMD:zaparkuj(playerid, params[], help)
 {
 	new string[256];
-	new VW = GetPlayerVirtualWorld(playerid); 
 	if(IsPlayerInAnyVehicle(playerid))
 	{
-        new lVeh = GetPlayerVehicleID(playerid);
-		new vID = VehicleUID[lVeh][vUID];
+        new vehicleID = GetPlayerVehicleID(playerid);
+		new vehicleUID = VehicleUID[vehicleID][vUID];
 		new lider = PlayerInfo[playerid][pLider];
         new org = gPlayerOrg[playerid];
 
-		new liderOwner = CarData[vID][c_OwnerType] == CAR_OWNER_FRACTION && \
-			lider == CarData[vID][c_Owner] && 
+		new liderOwner = CarData[vehicleUID][c_OwnerType] == CAR_OWNER_FRACTION && \
+			lider == CarData[vehicleUID][c_Owner] && 
 			lider > 0;
-		new orgOwner = CarData[vID][c_OwnerType] == CAR_OWNER_FAMILY && \
-			gPlayerOrgLeader[playerid] == CarData[vID][c_Owner] && \
+		new orgOwner = CarData[vehicleUID][c_OwnerType] == CAR_OWNER_FAMILY && \
+			gPlayerOrgLeader[playerid] == CarData[vehicleUID][c_Owner] && \
 			org > 0;
-		if(!IsCarOwner(playerid, lVeh) && !liderOwner && !orgOwner)
+		if(!IsCarOwner(playerid, vehicleID) && !liderOwner && !orgOwner)
 		{ 
 			return sendErrorMessage(playerid, "Ten pojazd nie nale¿y do Ciebie!");
 		}
-		if(IsAPlane(lVeh))
+		if(IsAPlane(vehicleID))
 		{
    			new pZone[MAX_ZONE_NAME];
 			GetPlayer2DZone(playerid, pZone, MAX_ZONE_NAME);
 			if((IsPlayerInRangeOfPoint(playerid, Dom[PlayerInfo[playerid][pDom]][hLadowisko], Dom[PlayerInfo[playerid][pDom]][hWej_X], Dom[PlayerInfo[playerid][pDom]][hWej_Y],  Dom[PlayerInfo[playerid][pDom]][hWej_Z]) && PlayerInfo[playerid][pDom] != 0) || strcmp(pZone, "Las Venturas Airport", true) == 0 || strcmp(pZone, "Lotnisko", true) == 0 || strcmp(pZone, "Easter Bay Airport", true) == 0 || strcmp(pZone, "Verdant Meadows", true) == 0 || liderOwner || orgOwner)
 			{
-                new Float:X, Float:Y, Float:Z;
-				new Float:A;
-				GetVehicleZAngle(lVeh, A);
-				GetPlayerPos(playerid, X,Y,Z);
+				new doRespawn = liderOwner || orgOwner;
+				saveCar(playerid, vehicleID, vehicleUID, doRespawn);
 
-                CarData[vID][c_Pos][0] = X;
-                CarData[vID][c_Pos][1] = Y;
-                CarData[vID][c_Pos][2] = Z;
-				CarData[vID][c_VW] = VW; 
-                CarData[vID][c_Rot] = A;
-                Car_Save(vID, CAR_SAVE_STATE);
-
-				format(string, sizeof(string), "Twój %s zosta³ zaparkowany w tym miejscu!", VehicleNames[GetVehicleModel(lVeh)-400]);
+				format(string, sizeof(string), "Twój %s zosta³ zaparkowany w tym miejscu!", VehicleNames[GetVehicleModel(vehicleID)-400]);
 				sendTipMessage(playerid, string, COLOR_LIGHTBLUE);
 			}
 			else
@@ -85,19 +75,10 @@ YCMD:zaparkuj(playerid, params[], help)
 		}
         else //NORM
         {
-            new Float:X, Float:Y, Float:Z;
-			new Float:A;
-			GetVehicleZAngle(lVeh, A);
-			GetPlayerPos(playerid, X,Y,Z);
+			new doRespawn = liderOwner || orgOwner;
+			saveCar(playerid, vehicleID, vehicleUID, doRespawn);
 
-            CarData[vID][c_Pos][0] = X;
-            CarData[vID][c_Pos][1] = Y;
-            CarData[vID][c_Pos][2] = Z;
-            CarData[vID][c_Rot] = A;
-			CarData[vID][c_VW] = VW; 
-            Car_Save(vID, CAR_SAVE_STATE);
-
-			format(string, sizeof(string), "Twój %s zosta³ zaparkowany w tym miejscu!", VehicleNames[GetVehicleModel(lVeh)-400]);
+			format(string, sizeof(string), "Twój %s zosta³ zaparkowany w tym miejscu!", VehicleNames[GetVehicleModel(vehicleID)-400]);
 			sendTipMessage(playerid, string, COLOR_LIGHTBLUE);
         }
 	}
@@ -106,4 +87,25 @@ YCMD:zaparkuj(playerid, params[], help)
 	    sendErrorMessage(playerid, "Nie jesteœ w wozie.");
 	}
 	return 1;
+}
+
+saveCar(playerid, vehicleID, vehicleUID, respawn)
+{
+	new Float:X, Float:Y, Float:Z;
+	new Float:A;
+	new VW = GetPlayerVirtualWorld(playerid); 
+	GetVehicleZAngle(vehicleID, A);
+	GetPlayerPos(playerid, X,Y,Z);
+
+	CarData[vehicleUID][c_Pos][0] = X;
+	CarData[vehicleUID][c_Pos][1] = Y;
+	CarData[vehicleUID][c_Pos][2] = Z;
+	CarData[vehicleUID][c_VW] = VW; 
+	CarData[vehicleUID][c_Rot] = A;
+	Car_Save(vehicleUID, CAR_SAVE_STATE);
+	if (respawn) 
+	{
+		Car_Unspawn(vehicleID);
+		Car_Spawn(vehicleUID);
+	}
 }

--- a/gamemodes/modules/antycheat/antycheat.pwn
+++ b/gamemodes/modules/antycheat/antycheat.pwn
@@ -533,7 +533,7 @@ AC_AntyVehSpamLag()
 	static Float:v_distance;
 	static v_close_count;
 	static string[128];
-	static v_pos[MAX_VEHICLES][3];
+	static Float:v_pos[MAX_VEHICLES][3];
 
 	// Zapisujemy pozycje wszystkich pojazdów na serwerze
 	foreach(new v : Vehicle)
@@ -631,6 +631,8 @@ IPacket:UNOCCUPIED_SYNC(playerid, BitStream:bs)
 	{
 		return 0;
 	}
+
+	return 1;
 }
 
 // ----------------<[ AntiVehicleSpawn (https://github.com/katursis/Pawn.RakNet/wiki/AntiVehicleSpawn) ]>-----------------------
@@ -646,7 +648,18 @@ IRPC:VEHICLE_DESTROYED(playerid, BitStream:bs)
         return 0;
     }
 
-    return OnVehicleRequestDeath(vehicleid, playerid);
+	new Float:health, Float:depth, Float:vehicledepth;
+
+    GetVehicleHealth(vehicleid, health);
+
+    if (health >= 250.0 &&
+        !CA_IsVehicleInWater(vehicleid, depth, vehicledepth) &&
+        !IsVehicleUpsideDown(vehicleid)
+    ) {
+        return 0;
+    }
+
+    return 1;
 }
 
 //end

--- a/gamemodes/modules/antycheat/antycheat.pwn
+++ b/gamemodes/modules/antycheat/antycheat.pwn
@@ -556,7 +556,7 @@ AC_AntyVehFakeRespawn(vehicleid, killerid)
 		if(currentTick - timeFakeVehRespawn[killerid] < 1200000)
 		{
 			countFakeVehRespawn[killerid]++;
-			if(countFakeVehRespawn[killerid] > 2)
+			if(countFakeVehRespawn[killerid] == 2 || (countFakeVehRespawn[killerid] > 2 && countFakeVehRespawn[killerid] % 30 == 0))
 			{
 				new string[128];
 				format(string, sizeof string, "AC: %s [%d] czêsto zg³asza utopienie pojazdów, mo¿e wymuszaæ respawn pojazdu [Veh: %d].", GetNickEx(killerid), killerid, vehicleid);

--- a/gamemodes/modules/antycheat/antycheat.pwn
+++ b/gamemodes/modules/antycheat/antycheat.pwn
@@ -514,4 +514,185 @@ AC_AntyFakeKill(playerid, killerid, reason)
 	return 1;
 }
 
+public AC_AntyVehFakeRespawnTimer(vehicleid, killerid)
+{
+	if(IsPlayerConnected(killerid))
+	{
+		new Float:veh_health;
+		GetVehicleHealth(vehicleid, veh_health);
+
+		// Ponowne upewnienie siê, ¿e auto nie wybuch³o - bez tego system czasem fa³szywie wykrywa czita
+		if(veh_health >= 260.0)
+		{
+			new string[128];
+			SendClientMessage(killerid, COLOR_PANICRED, "AC: Dosta³eœ kicka za próbê wymuszenia respawnu pojazdu!");
+			format(string, sizeof string, "AC: %s dosta³ kicka za próbê wymuszenia respawnu pojazdu [Veh: %d].", GetNickEx(killerid), vehicleid);
+			SendCommandLogMessage(string);
+			Log(warningLog, INFO, string);
+			Log(punishmentLog, INFO, string);
+			KickEx(killerid);
+		}
+	}
+}
+
+// Spam OnVehicleDeath
+AC_AntyVehFakeRespawn(vehicleid, killerid)
+{
+	new Float:veh_health, Float:veh_pos[3];
+	GetVehicleHealth(vehicleid, veh_health);
+	GetVehiclePos(vehicleid, veh_pos[0], veh_pos[1], veh_pos[2]);
+
+	// Auto ani nie eksplodowa³o - ma wiêcej ni¿ 250 HP (margines b³êdu 10, czyli 260 HP), ani nie jest potencjalnie pod wod¹ - ma Z-pos wiêkszy ni¿ 0.0 (z marginesem b³êdu 5.0)
+	if(veh_health >= 260.0 && veh_pos[2] > 5.0 && GetPVarInt(killerid, "AntyCheatOff") == 0)
+	{
+		SetTimerEx("AC_AntyVehFakeRespawnTimer", 5000, 0, "ii", vehicleid, killerid); // Ponowne upewnienie siê, ¿e auto nie wybuch³o - bez tego system czasem fa³szywie wykrywa czita
+	}
+
+	// cziter nadal mo¿e sobie waln¹æ wóz poni¿ej 5.0 w osi Z i wtedy daæ respawna
+	// jak ktoœ topi  auta (albo "topi", a w rzeczywistoœci oszukuje) czêœciej ni¿ 2 razy na 20 minut, to wyœlij warninga adminom
+	if(veh_pos[2] <= 5.0)
+	{
+		new currentTick = GetTickCount();
+		if(currentTick - timeFakeVehRespawn[killerid] < 1200000)
+		{
+			countFakeVehRespawn[killerid]++;
+			if(countFakeVehRespawn[killerid] > 2)
+			{
+				new string[128];
+				format(string, sizeof string, "AC: %s [%d] czêsto zg³asza utopienie pojazdów, mo¿e wymuszaæ respawn pojazdu [Veh: %d].", GetNickEx(killerid), killerid, vehicleid);
+				SendCommandLogMessage(string);
+				Log(warningLog, INFO, string);
+			}
+		}
+		else
+		{
+			countFakeVehRespawn[killerid] = 1;
+			timeFakeVehRespawn[killerid] = currentTick;
+		}
+	}
+}
+
+// Spam UnoccupiedSync i przenoszenie aut w kupê - lagi
+AC_AntyVehSpamLag()
+{
+	if(!performUnoccupiedVehCheckAC)
+	{
+		return;
+	}
+
+	static Float:v_distance;
+	static v_close_count;
+	static string[128];
+	static v_pos[MAX_VEHICLES][3];
+
+	// Zapisujemy pozycje wszystkich pojazdów na serwerze
+	foreach(new v : Vehicle)
+	{
+		GetVehiclePos(v, v_pos[v][0], v_pos[v][1], v_pos[v][2]);
+	}
+
+	foreach(new v : Vehicle)
+	{
+		// Czy pojazd zosta³ przesuniêty przez synchronizacjê auta bez kierowcy?
+		if(unoccupiedVehToCheckAC[v])
+		{
+			v_close_count = 0;
+			new v_to_respawn[MAX_VEHICLES] = {false, ...}, p_sus_syncs[MAX_PLAYERS] = {0, ...};
+
+			// Zliczanie ile innych pojazdów znajduje siê w b. bliskiej odleg³oœci od auta przesuniêtego przez UnoccupiedSync
+			foreach(new v_other : Vehicle)
+			{
+				if(v != v_other)
+				{
+					v_distance = GetDistanceBetweenPoints(v_pos[v][0], v_pos[v][1], v_pos[v][2], 
+						v_pos[v_other][0], v_pos[v_other][1], v_pos[v_other][2]);
+
+					if(v_distance <= 2.0)
+					{
+						v_close_count++;
+						v_to_respawn[v_other] = true;
+					}
+				}
+			}
+
+			// Je¿eli pojazdów zbitych w zwarte k³êbowisko jest nie mniej ni¿ 3, to podejmij odpowiednie dzia³ania
+			if(v_close_count >= 3)
+			{
+				v_to_respawn[v] = true;
+
+				new blockUnoccupiedThreshold = floatround(1.0 / 3.0 * float(v_close_count));
+				new sendAdminWarningThreshold = floatround(0.9 * float(v_close_count));
+
+				foreach(new v_respawn : Vehicle)
+				{
+					if(v_to_respawn[v_respawn])
+					{
+						// Sprawdzamy którzy gracze zsynchronizowali zmianê pozycji pojazdu bêd¹cego czêœci¹ k³êbowiska
+						foreach(new p : Player)
+						{
+							if(p_sus_syncs[p] != -1 && unoccupiedVehToCheckPlayersAC[v_respawn][p])
+							{
+								p_sus_syncs[p]++; // Zliczamy dla ilu pojazdów z k³êbowiska zmiana pozycji zosta³a zsynchronizowana przez danego gracza
+
+								// Je¿eli gracz zsynchronizowa³ zmiany pozycji dla wystarczaj¹cej liczby pojazdów z k³êbowiska, podejmujemy odpowiednie dzia³ania
+								if(p_sus_syncs[p] == blockUnoccupiedThreshold)
+								{
+									unoccupiedVehBlockAC[p] = true;
+									format(string, sizeof string, "AC: %s [%d] dosta³ blokadê na synchronizacjê pojazdów bez kierowcy.", GetNickEx(p), p);
+									SendCommandLogMessage(string);
+								}
+								if(p_sus_syncs[p] == sendAdminWarningThreshold)
+								{
+									format(string, sizeof string, "AC: %s [%d] BYÆ MO¯E próbuje lagowaæ pojazdami.", GetNickEx(p), p);
+									SendCommandLogMessage(string);
+									Log(warningLog, INFO, string);
+									p_sus_syncs[p] = -1; // oznaczenie, ¿e gracz przekroczy³ ju¿ najwy¿szy próg i nie trzeba go sprawdzaæ dla kolejnych pojazdów w k³êbowisku
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// Po rozprawieniu siê z potencjalnymi winowajcami, zrespawnuj auta w k³êbowisku
+			foreach(new v_respawn : Vehicle)
+			{
+				if(v_to_respawn[v_respawn])
+				{
+					unoccupiedVehToCheckAC[v_respawn] = false; // Nie ma sensu po raz kolejny sprawdzaæ tych aut, bo zosta³y one ju¿ zrespawnowane
+					RespawnVehicleEx(v_respawn);
+				}
+			}
+
+			foreach(new p : Player)
+			{
+				unoccupiedVehToCheckPlayersAC[v][p] = false;
+			}
+		}
+	}
+
+	performUnoccupiedVehCheckAC = false;
+}
+
+
+hook OnUnoccupiedVehicleUpdate(vehicleid, playerid, passenger_seat, Float:new_x, Float:new_y, Float:new_z, Float:vel_x, Float:vel_y, Float:vel_z)
+{
+	// Sprawdzenie czy na gracza zosta³a na³o¿ona blokada na synchronizacje pojazdów bez kierowcy
+	if(unoccupiedVehBlockAC[playerid])
+	{
+		return 0;
+	}
+
+	new Float:old_x, Float:old_y, Float:old_z;
+	GetVehiclePos(vehicleid, old_x, old_y, old_z);
+	if(old_x != new_x || old_y != new_y || old_z != new_z)
+	{
+		unoccupiedVehToCheckAC[vehicleid] = true;
+		unoccupiedVehToCheckPlayersAC[vehicleid][playerid] = true;
+		performUnoccupiedVehCheckAC = true;
+	}
+
+	return 1;
+}
+
 //end

--- a/gamemodes/modules/antycheat/antycheat_callbacks.pwn
+++ b/gamemodes/modules/antycheat/antycheat_callbacks.pwn
@@ -211,21 +211,4 @@ hook OnUnoccupiedVehicleUpdate(vehicleid, playerid, passenger_seat, Float:new_x,
 	return 1;
 }
 
-forward OnVehicleRequestDeath(vehicleid, killerid);
-public OnVehicleRequestDeath(vehicleid, killerid)
-{
-    new Float:health, Float:depth, Float:vehicledepth;
-
-    GetVehicleHealth(vehicleid, health);
-
-    if (health >= 250.0 &&
-        !CA_IsVehicleInWater(vehicleid, depth, vehicledepth) &&
-        !IsVehicleUpsideDown(vehicleid)
-    ) {
-        return 0;
-    }
-
-    return 1;
-}
-
 //end

--- a/gamemodes/modules/antycheat/antycheat_callbacks.pwn
+++ b/gamemodes/modules/antycheat/antycheat_callbacks.pwn
@@ -197,4 +197,35 @@ AC_OnPlayerLogin(playerid)
 	}
 }
 
+hook OnUnoccupiedVehicleUpdate(vehicleid, playerid, passenger_seat, Float:new_x, Float:new_y, Float:new_z, Float:vel_x, Float:vel_y, Float:vel_z)
+{
+	new Float:old_x, Float:old_y, Float:old_z;
+	GetVehiclePos(vehicleid, old_x, old_y, old_z);
+	if(old_x != new_x || old_y != new_y || old_z != new_z)
+	{
+		unoccupiedVehToCheckAC[vehicleid] = true;
+		unoccupiedVehToCheckPlayersAC[vehicleid][playerid] = true;
+		performUnoccupiedVehCheckAC = true;
+	}
+
+	return 1;
+}
+
+forward OnVehicleRequestDeath(vehicleid, killerid);
+public OnVehicleRequestDeath(vehicleid, killerid)
+{
+    new Float:health, Float:depth, Float:vehicledepth;
+
+    GetVehicleHealth(vehicleid, health);
+
+    if (health >= 250.0 &&
+        !CA_IsVehicleInWater(vehicleid, depth, vehicledepth) &&
+        !IsVehicleUpsideDown(vehicleid)
+    ) {
+        return 0;
+    }
+
+    return 1;
+}
+
 //end

--- a/gamemodes/modules/weryfikacje/weryfikacje.pwn
+++ b/gamemodes/modules/weryfikacje/weryfikacje.pwn
@@ -119,7 +119,7 @@ ALockdown_Notify(playerid, type, user = -1)
 ALockdown_ExcludeFromPlaying(playerid)
 {
 	Lockdown_assignedVW[playerid] = random(500) + 101;
-	SetPlayerVirtualWorld(playerid, Lockdown_assignedVW[playerid]);
+	ALockdown_SetLockdownVW(playerid);
 	SetPVarInt(playerid, "Lockdown-izolacja", 1);
 	ALockdown_Notify(playerid, LOCKDOWN_MSG_JOINEDSERVER);
 	Lockdown_Timer[playerid] = SetTimerEx("ALockdown_Timer",700,true,"d",playerid);
@@ -160,7 +160,7 @@ public ALockdown_Timer(playerid)
 				KickEx(playerid);
 				ALockdown_DestroyData(playerid);
 			}
-			SetPlayerVirtualWorld(playerid, Lockdown_assignedVW[playerid]);
+			ALockdown_SetLockdownVW(playerid);
 		}
 		Lockdown_MSGCounter[playerid]++;
 		if(Lockdown_MSGCounter[playerid] >= 270)

--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -1,6 +1,10 @@
 //funkcje.pwn
 //FUNKCJE DLA CA£EGO SERWERA
 
+Float:GetDistanceBetweenPoints(Float:x1, Float:y1, Float:z1, Float:x2, Float:y2, Float:z2)
+{
+    return VectorSize(x1-x2, y1-y2, z1-z2);
+}
 
 /* SSCANF FIX */
 SSCANF:fix(string[])

--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -12486,6 +12486,20 @@ PursuitMode(playerid, giveplayerid)
 	}
 }
 
+// https://github.com/katursis/Pawn.RakNet/wiki/AntiVehicleSpawn
+stock IsVehicleUpsideDown(vehicleid)
+{
+    new Float:quat_w, Float:quat_x, Float:quat_y, Float:quat_z;
+    GetVehicleRotationQuat(vehicleid, quat_w, quat_x, quat_y, quat_z);
+    return (
+        floatabs(
+            atan2(2 * (quat_y * quat_z + quat_w * quat_x),
+                quat_w * quat_w - quat_x * quat_x - quat_y * quat_y + quat_z * quat_z
+            )
+        ) > 90.0
+    );
+}
+
 public DeathAdminWarning(playerid, killerid, reason)
 {
 	new killername[MAX_PLAYER_NAME];

--- a/gamemodes/system/timery.pwn
+++ b/gamemodes/system/timery.pwn
@@ -938,7 +938,7 @@ public MainTimer()
     }
     if(TICKS_3Sec == 2)
     {
-    	AC_AntyVehSpamLag()
+    	AC_AntyVehSpamLag();
         VehicleUpdate();
         CustomPickups();
         GangZone_ShowInfoToParticipants();

--- a/gamemodes/system/timery.pwn
+++ b/gamemodes/system/timery.pwn
@@ -1,5 +1,7 @@
 //timery.pwn
 
+forward AC_AntyVehSpamLag();
+
 //25.06.2014 Aktualizacja timerów (wszystkich) - optymalizacja Kubi
 forward SpecToggle(playerid);
 public SpecToggle(playerid)
@@ -936,7 +938,7 @@ public MainTimer()
     }
     if(TICKS_3Sec == 2)
     {
-    	
+    	AC_AntyVehSpamLag()
         VehicleUpdate();
         CustomPickups();
         GangZone_ShowInfoToParticipants();

--- a/gamemodes/system/zmienne.pwn
+++ b/gamemodes/system/zmienne.pwn
@@ -1121,7 +1121,7 @@ ZerujZmienne(playerid)
 	//z disconecta
 
 	timeFakeVehRespawn[playerid] = 0;
-	countFakeVehRespawn[playerid] = 0
+	countFakeVehRespawn[playerid] = 0;
 
     new Text3D:tmp_label = PlayerInfo[playerid][pDescLabel];
 

--- a/gamemodes/system/zmienne.pwn
+++ b/gamemodes/system/zmienne.pwn
@@ -25,7 +25,15 @@ new Float:czitY;
 new Float:czitZ;
 
 new timerAC[MAX_PLAYERS];
-new timeAC[MAX_PLAYERS]; 
+new timeAC[MAX_PLAYERS];
+
+new timeFakeVehRespawn[MAX_PLAYERS] = {0, ...}; // czas (tick) kiedy gracz ostatnio utopi³ pojazd (albo udawa³, ¿e go utopi³, by je zrespawnowaæ)
+new countFakeVehRespawn[MAX_PLAYERS] = {0, ...}; // ile razy w ci¹gu ostatnich 20 minut gracz utopi³ pojazd (albo udawa³, ¿e go utopi³, by je zrespawnowaæ)
+new unoccupiedVehToCheckAC[MAX_VEHICLES] = {false, ...}; // true je¿eli w przeci¹gu ostatnich 3 sekund pozycja danego pojazdu zosta³a zmieniona przez synchronizacjê pojazdu bez kierowcy (UnoccupiedSync)
+new unoccupiedVehToCheckPlayersAC[MAX_VEHICLES][MAX_PLAYERS] = {{false, ...}, ...}; // true dla danego pojazdu v i dla danego gracza p, jezeli to gracz p dokona³ synchronizacji pojazdu v (UnoccupiedSync)
+new unoccupiedVehBlockAC[MAX_PLAYERS] = {false, ...}; // true je¿eli na gracza zosta³a za³o¿ona blokada synchronizacji pojazdów bez kierowcy
+new performUnoccupiedVehCheckAC = false; // true je¿eli pozycja któregokolwiek pojazdu zosta³a zmieniona w przeci¹gu ostatnich 3 sekund przez synchronizacjê typu UnoccupiedSync
+
 //doors
 new noAccessCome[MAX_PLAYERS]; 
 
@@ -1112,6 +1120,9 @@ ZerujZmienne(playerid)
 	organizacje_clearCache(playerid);
 	//z disconecta
 
+	timeFakeVehRespawn[playerid] = 0;
+	countFakeVehRespawn[playerid] = 0
+
     new Text3D:tmp_label = PlayerInfo[playerid][pDescLabel];
 
     PlayerInfo[playerid][pDescLabel] = tmp_label;
@@ -1439,6 +1450,10 @@ ZerujZmienne(playerid)
 
     strdel(PlayerDesc[playerid], 0, 128 char);
     strpack(PlayerDesc[playerid], "BRAK");
+
+	foreach(new v : Vehicle) unoccupiedVehToCheckPlayersAC[v][playerid] = false;
+		unoccupiedVehBlockAC[playerid] = false;
+
 	return 1;
 }
 //EOF

--- a/pawn.json
+++ b/pawn.json
@@ -20,7 +20,7 @@
 		"BigETI/pawn-memory:v2.0.1",
 		"BigETI/pawn-vector",
 		"IllidanS4/PawnPlus:v1.1",
-		"Pottus/ColAndreas:v1.5.0",
+		"Pottus/ColAndreas#7e0dada038adbf23089c334bba5acad31cc567d0",
 		"BigETI/pawn-map",
 		"Mrucznik/indirection",
 		"Mrucznik/amx_assembly:v4.69",

--- a/pawn.json
+++ b/pawn.json
@@ -20,13 +20,14 @@
 		"BigETI/pawn-memory:v2.0.1",
 		"BigETI/pawn-vector",
 		"IllidanS4/PawnPlus:v1.1",
-		"Pottus/ColAndreas:v1.4.0.3",
+		"Pottus/ColAndreas:v1.5.0",
 		"BigETI/pawn-map",
 		"Mrucznik/indirection",
 		"Mrucznik/amx_assembly:v4.69",
 		"Mrucznik/samp-plugin-profiler:v2.15.4",
 		"Southclaws/progress2",
-		"oscar-broman/samp-inline-sort"
+		"oscar-broman/samp-inline-sort",
+		"katursis/Pawn.RakNet:1.6.0"
 	],
 	"build": {
 		"name": "",


### PR DESCRIPTION
Dodanie ochrony przed złośliwym respawnowaniem pojazdów oraz lagowaniem ich kłębowiskami.

Zainstalowanie Pawn.RakNet i nowego include'a do ColAndreas. 
Opis związanych z tym zmian w serverfiles.tar.gz (można rozpakować i sprawdzić sobie diffem):
- dodanie do folderu _plugins_ pliku _pawnraknet.so_ - pochodzi on z tego wydania Pawn.Raknetu: https://github.com/katursis/Pawn.RakNet/releases/tag/1.6.0;
- dodanie do folderu _scriptfiles/colandreas_ wygenerowanej mapy kolizji w postaci pliku _ColAndreas.cadb_;
- zmiany w _server.cfg_ polegające na dopisaniu _pawnraknet.so ColAndreas_static.so_ na końcu linijki _plugins_;

Zrobiłem też include'a wygodnie integrującego ColAndreas i streamera obiektów od Incognito - PR: https://github.com/Mrucznik/Mrucznik-RP-Includes/pull/7.

W związku z dodaniem ColAndreas dodałem też PR do obiektów: https://github.com/Mrucznik/Mrucznik-RP-obiekty/pull/88.