### PR TITLE
Poprawka do /brama

### DIFF
--- a/gamemodes/dialogs/OnDialogResponse.pwn
+++ b/gamemodes/dialogs/OnDialogResponse.pwn
@@ -2967,7 +2967,7 @@ public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 	            {
 					case 0:
 					{
-						if (kaska[playerid] > 50000)
+						if (kaska[playerid] > 56500)
 						{
 							if(PlayerGames[playerid] >= 4)
 							{
@@ -2979,7 +2979,7 @@ public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 							ProxDetector(20.0, playerid, string,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE);
 							new winValue = true_random(100);
 							new playerValue = true_random(100);
-							ZabierzKase(playerid, 50000);
+							ZabierzKase(playerid, 56500);
 						    if(PlayerInfo[playerid][pTraderPerk] > 0)
 						    { 
 								if(playerValue > winValue && playerValue >= 85)

--- a/gamemodes/modules/bramy/bramy.pwn
+++ b/gamemodes/modules/bramy/bramy.pwn
@@ -140,7 +140,7 @@ SprawdzBramy(playerid)
 {
 	for(new i; i<iloscbram; i++)
 	{	
-		if(GetPlayerVirtualWorld(playerid) == bramy[i][b_vw])
+		if(GetPlayerVirtualWorld(playerid) == bramy[i][b_vw] || bramy[i][b_vw] == -1)
 		{
 			if(IsPlayerInRangeOfPoint(playerid, bramy[i][b_range], bramy[i][duo_x1], bramy[i][duo_y1], bramy[i][duo_z1]) || IsPlayerInRangeOfPoint(playerid, bramy[i][b_range], bramy[i][duo_x2], bramy[i][duo_y2], bramy[i][duo_z2]))
 			{


### PR DESCRIPTION
Jack_Evans zreportował zbugowaną bramę od domu, po analizie niektóre z bram mają ustawione vw na -1 w streamerze, poprawka która ignoruje sprawdzanie VW gracza, jeżeli VW bramy jest ustawione na -1