### PR TITLE
Naprawa GetVehicleRotationQuat dla aut bez kierowcy.

### DIFF
--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -108,6 +108,7 @@ Mrucznik® Role Play ----> stworzy³ Mrucznik
 #include <vector>
 #include <map>
 #include <mapfix>
+#include <getvehiclerotationquat_fix>
 
 //--------------------------------------<[ G³ówne ustawienia ]>----------------------------------------------//
 //-                                                                                                         -//


### PR DESCRIPTION
Napisałem include do naprawy GetVehicleRotationQuat (a więc i GetVehicleRotation) dla aut bez kierowcy.

PR: https://github.com/Mrucznik/Mrucznik-RP-Includes/pull/8